### PR TITLE
Bugfix: setMap throws A System.NullReferenceException when clicking t…

### DIFF
--- a/Source/FindDescription.cs
+++ b/Source/FindDescription.cs
@@ -63,6 +63,7 @@ namespace List_Everything
 
 		public FindDescription(Map m)
 		{
+			children = new FilterHolder(this);
 			map = m;
 		}
 


### PR DESCRIPTION
Hi, I've just build the project and tried to push the find button and got this exception 

```
Root level exception in OnGUI(): System.NullReferenceException: Object reference not set to an instance of an object
  at List_Everything.FindDescription.CurrentMapOnly () [0x00006] in <e6f61ab7cf134f7792582b366e4613c8>:0 
  at List_Everything.FindDescription.set_map (Verse.Map value) [0x000aa] in <e6f61ab7cf134f7792582b366e4613c8>:0 
  at List_Everything.FindDescription..ctor (Verse.Map m) [0x0004c] in <e6f61ab7cf134f7792582b366e4613c8>:0 
  at List_Everything.MainTabWindow_List.SetFindDesc (List_Everything.FindDescription fd, System.Boolean l) [0x00029] in <e6f61ab7cf134f7792582b366e4613c8>:0 
  at List_Everything.MainTabWindow_List.PreOpen () [0x00016] in <e6f61ab7cf134f7792582b366e4613c8>:0 
  at Verse.WindowStack.Add (Verse.Window window) [0x0001f] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.MainTabsRoot.ToggleTab (RimWorld.MainButtonDef newTab, System.Boolean playSound) [0x0006b] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.MainButtonWorker_ToggleTab.Activate () [0x00005] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.MainButtonWorker.InterfaceTryActivate () [0x0008d] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.MainButtonWorker.DoButton (UnityEngine.Rect rect) [0x000ee] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.MainButtonsRoot.DoButtons () [0x00119] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.MainButtonsRoot.MainButtonsOnGUI () [0x0000e] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.UIRoot_Play.UIRootOnGUI () [0x00037] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at Verse.Root.OnGUI () [0x0003d] in <1782cb69665b4d3abcdadb97df9ae541>:0  
(Filename: C:\buildslave\unity\build\Runtime/Export/Debug/Debug.bindings.h Line: 39)```

I've traced it to the fact that the constructor FindDescription(map) calls setmap before setting the children. This is a simple fix where I've placed the constructor calling the same code as the empty constructor first.